### PR TITLE
fix(main.sh): add message for registry auth deployment

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,8 +40,7 @@ inputs:
     required: false
   with_registry_auth:
     description: "Should deploy using registry auth"
-    type: boolean
-    default: false
+    default: 'false'
     required: false
 
 runs:

--- a/src/main.sh
+++ b/src/main.sh
@@ -72,6 +72,7 @@ fi
 
 echo -e "\u001b[36mDeploying Stack: \u001b[37;1m${INPUT_NAME}"
 if [[ "${INPUT_WITH_REGISTRY_AUTH}" == "true" ]];then
+  echo -e "\u001b[36mDeploying with registry auth \u001b[37;1m"
   docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}" --with-registry-auth
 else
   docker stack deploy -c "${INPUT_FILE}" "${INPUT_NAME}"


### PR DESCRIPTION
Added a log message to indicate when deploying with registry authentication. This improves clarity during the deployment process by providing better feedback in the console output.